### PR TITLE
Set flag to prompt for sudo password on setup.yml

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -61,7 +61,8 @@ Use `ansible-galaxy` to download dependencies in the following way:
 `setup.yml` will configure the localhost as an Ansible control server in the following way:
     
     # Setup the Ansible controller
-    ansible-playbook setup.yml
+    ansible-playbook setup.yml --ask-become-pass
+
 
 ## Configuration Review
 


### PR DESCRIPTION
The setup playbook requires privilege escalation. 
If the user runs the playbook with an account that requires
password to be entered when sudo'ing, then ansible should
prompt the user for the password.